### PR TITLE
Stop, pause, resume 

### DIFF
--- a/src/interfaces/midi-output.ts
+++ b/src/interfaces/midi-output.ts
@@ -2,4 +2,6 @@
 
 export interface IMidiOutput {
     send(data: number[] | Uint8Array, timestamp?: number): void;
+
+    clear(): void;
 }

--- a/src/interfaces/midi-output.ts
+++ b/src/interfaces/midi-output.ts
@@ -1,7 +1,7 @@
 // This is an incomplete version of the MIDIOutput specification.
 
 export interface IMidiOutput {
-    send(data: number[] | Uint8Array, timestamp?: number): void;
+    clear?(): void;
 
-    clear(): void;
+    send(data: number[] | Uint8Array, timestamp?: number): void;
 }

--- a/src/interfaces/midi-player.ts
+++ b/src/interfaces/midi-player.ts
@@ -1,13 +1,13 @@
 import { PlayerState } from '../types/player-state';
 
 export interface IMidiPlayer {
-    play(): Promise<void>;
+    readonly state: PlayerState;
 
     pause(): void;
+
+    play(): Promise<void>;
 
     resume(): Promise<void>;
 
     stop(): void;
-
-    get state(): PlayerState;
 }

--- a/src/interfaces/midi-player.ts
+++ b/src/interfaces/midi-player.ts
@@ -1,11 +1,12 @@
+import { PlayerState } from '../types/player-state';
 export interface IMidiPlayer {
     play(): Promise<void>;
 
     pause(): void;
 
-    resume(): void;
+    resume(): Promise<void>;
 
     stop(): void;
 
-    get playing(): boolean;
+    get state(): PlayerState;
 }

--- a/src/interfaces/midi-player.ts
+++ b/src/interfaces/midi-player.ts
@@ -1,3 +1,11 @@
 export interface IMidiPlayer {
     play(): Promise<void>;
+
+    pause(): void;
+
+    resume(): void;
+
+    stop(): void;
+
+    get playing(): boolean;
 }

--- a/src/interfaces/midi-player.ts
+++ b/src/interfaces/midi-player.ts
@@ -1,4 +1,5 @@
 import { PlayerState } from '../types/player-state';
+
 export interface IMidiPlayer {
     play(): Promise<void>;
 

--- a/src/midi-player.ts
+++ b/src/midi-player.ts
@@ -72,7 +72,7 @@ export class MidiPlayer implements IMidiPlayer {
 
         this._pause();
 
-        this._paused = this._scheduler.performance.now();
+        this._paused = this._scheduler.now();
     }
 
     public resume(): Promise<void> {
@@ -80,7 +80,7 @@ export class MidiPlayer implements IMidiPlayer {
             throw new Error('The player is not currently paused.');
         }
 
-        this._offset! += this._scheduler.performance.now() - this._paused!;
+        this._offset! += this._scheduler.now() - this._paused!;
 
         return this._promise();
     }

--- a/src/midi-player.ts
+++ b/src/midi-player.ts
@@ -111,9 +111,7 @@ export class MidiPlayer implements IMidiPlayer {
             this._schedulerSubscription = null;
         }
 
-        if (this._midiOutput && this._midiOutput.clear) {
-            this._midiOutput.clear();
-        }
+        this._midiOutput.clear?.();
 
         this._channels?.forEach(channel => {
             const allSoundOff = this._encodeMidiMessage({

--- a/src/midi-player.ts
+++ b/src/midi-player.ts
@@ -60,6 +60,30 @@ export class MidiPlayer implements IMidiPlayer {
         });
     }
 
+    public pause(): void {
+        if (this._resolve !== null) {
+            this._resolve();
+            this._resolve = null;
+        }
+        if (this._schedulerSubscription !== null) {
+            this._schedulerSubscription?.unsubscribe();
+            this._schedulerSubscription = null;
+        }
+    }
+
+    public resume(): void {}
+
+    public stop(): void {
+        this.pause();
+
+        this._offset = null;
+        this._endedTracks = null;
+    }
+
+    public get playing(): boolean {
+        return this._schedulerSubscription !== null && this._resolve !== null;
+    }
+
     private _schedule(start: number, end: number): void {
         if (this._endedTracks === null || this._offset === null || this._resolve === null) {
             throw new Error(); // @todo

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -23,8 +23,8 @@ export class Scheduler {
         this._subject = new Subject();
     }
 
-    public get performance(): Window['performance'] {
-        return this._performance;
+    public now(): number {
+        return this._performance.now();
     }
 
     public subscribe(observer: Partial<Observer<IInterval>>): { unsubscribe(): void } {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -23,6 +23,10 @@ export class Scheduler {
         this._subject = new Subject();
     }
 
+    public get performance(): Window['performance'] {
+        return this._performance;
+    }
+
     public subscribe(observer: Partial<Observer<IInterval>>): { unsubscribe(): void } {
         this._numberOfSubscribers += 1;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './midi-file-slicer-factory';
 export * from './midi-player-factory';
 export * from './midi-player-factory-factory';
+export * from './player-state';

--- a/src/types/player-state.ts
+++ b/src/types/player-state.ts
@@ -1,0 +1,5 @@
+export enum PlayerState {
+    Stopped,
+    Playing,
+    Paused
+}


### PR DESCRIPTION
This PR intoduces new player functionality: stop, pause, resume. It also introduces an associated player state which can be "playing", "stopped" or "paused". The state is computed based on existing variables.

To implement pause / resume, we need to remember the time at which the player was paused, and then adjust the offset when it is resumed.

I also added `IMidiOutput.clear()` which is part of the Web MIDI standard. This method is called if it is available in the output object.