### PR TITLE
Stop scheduled midi notes

### DIFF
--- a/config/grunt/aliases.js
+++ b/config/grunt/aliases.js
@@ -1,5 +1,5 @@
 module.exports = {
     build: ['sh:build'],
     lint: ['sh:lint-config', 'sh:lint-src', 'sh:lint-test'],
-    test: ['sh:test-unit']
+    test: ['sh:test-expectation-chrome', 'sh:test-expectation-chrome-canary', 'sh:test-unit']
 };

--- a/config/grunt/aliases.js
+++ b/config/grunt/aliases.js
@@ -1,5 +1,20 @@
+const { env } = require('process');
+
+// eslint-disable-next-line padding-line-between-statements
+const filter = (predicate, ...tasks) => (predicate ? tasks : []);
+const isTarget = (...targets) => env.TARGET === undefined || targets.includes(env.TARGET);
+const isType = (...types) => env.TYPE === undefined || types.includes(env.TYPE);
+
 module.exports = {
     build: ['sh:build'],
     lint: ['sh:lint-config', 'sh:lint-src', 'sh:lint-test'],
-    test: ['sh:test-expectation-chrome', 'sh:test-expectation-chrome-canary', 'sh:test-unit']
+    test: [
+        'build',
+        ...filter(
+            isType('expectation'),
+            ...filter(isTarget('chrome'), 'sh:test-expectation-chrome'),
+            ...filter(isTarget(), 'sh:test-expectation-chrome-canary')
+        ),
+        ...filter(isType('unit'), 'sh:test-unit')
+    ]
 };

--- a/config/grunt/sh.js
+++ b/config/grunt/sh.js
@@ -14,6 +14,12 @@ module.exports = (grunt) => {
         'lint-test': {
             cmd: 'npm run lint:test'
         },
+        'test-expectation-chrome': {
+            cmd: `karma start config/karma/config-expectation-chrome.js ${continuous ? '--concurrency Infinity' : '--single-run'}`
+        },
+        'test-expectation-chrome-canary': {
+            cmd: `karma start config/karma/config-expectation-chrome-canary.js ${continuous ? '--concurrency Infinity' : '--single-run'}`
+        },
         'test-unit': {
             cmd: `karma start config/karma/config-unit.js ${continuous ? '--concurrency Infinity' : '--single-run'}`
         }

--- a/config/karma/config-expectation-chrome-canary.js
+++ b/config/karma/config-expectation-chrome-canary.js
@@ -1,0 +1,68 @@
+const { env } = require('process');
+const { DefinePlugin } = require('webpack');
+
+module.exports = (config) => {
+    config.set({
+        basePath: '../../',
+
+        browserDisconnectTimeout: 100000,
+
+        browserNoActivityTimeout: 100000,
+
+        browsers: ['ChromeCanaryHeadless'],
+
+        client: {
+            mocha: {
+                bail: true,
+                timeout: 20000
+            }
+        },
+
+        concurrency: 1,
+
+        files: ['test/expectation/chrome/canary/**/*.js'],
+
+        frameworks: ['mocha', 'sinon-chai'],
+
+        preprocessors: {
+            'test/expectation/chrome/canary/**/*.js': 'webpack'
+        },
+
+        reporters: ['dots'],
+
+        webpack: {
+            mode: 'development',
+            module: {
+                rules: [
+                    {
+                        test: /\.ts?$/,
+                        use: {
+                            loader: 'ts-loader',
+                            options: {
+                                compilerOptions: {
+                                    declaration: false,
+                                    declarationMap: false
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            plugins: [
+                new DefinePlugin({
+                    'process.env': {
+                        CI: JSON.stringify(env.CI)
+                    }
+                })
+            ],
+            resolve: {
+                extensions: ['.js', '.ts'],
+                fallback: { util: false }
+            }
+        },
+
+        webpackMiddleware: {
+            noInfo: true
+        }
+    });
+};

--- a/config/karma/config-expectation-chrome.js
+++ b/config/karma/config-expectation-chrome.js
@@ -1,0 +1,68 @@
+const { env } = require('process');
+const { DefinePlugin } = require('webpack');
+
+module.exports = (config) => {
+    config.set({
+        basePath: '../../',
+
+        browserDisconnectTimeout: 100000,
+
+        browserNoActivityTimeout: 100000,
+
+        browsers: ['ChromeHeadless'],
+
+        client: {
+            mocha: {
+                bail: true,
+                timeout: 20000
+            }
+        },
+
+        concurrency: 1,
+
+        files: ['test/expectation/chrome/current/**/*.js'],
+
+        frameworks: ['mocha', 'sinon-chai'],
+
+        preprocessors: {
+            'test/expectation/chrome/current/**/*.js': 'webpack'
+        },
+
+        reporters: ['dots'],
+
+        webpack: {
+            mode: 'development',
+            module: {
+                rules: [
+                    {
+                        test: /\.ts?$/,
+                        use: {
+                            loader: 'ts-loader',
+                            options: {
+                                compilerOptions: {
+                                    declaration: false,
+                                    declarationMap: false
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            plugins: [
+                new DefinePlugin({
+                    'process.env': {
+                        CI: JSON.stringify(env.CI)
+                    }
+                })
+            ],
+            resolve: {
+                extensions: ['.js', '.ts'],
+                fallback: { util: false }
+            }
+        },
+
+        webpackMiddleware: {
+            noInfo: true
+        }
+    });
+};

--- a/src/interfaces/midi-output.ts
+++ b/src/interfaces/midi-output.ts
@@ -1,5 +1,7 @@
 // This is an incomplete version of the MIDIOutput specification.
 
 export interface IMidiOutput {
+    clear?(): void;
+
     send(data: number[] | Uint8Array, timestamp?: number): void;
 }

--- a/src/midi-player.ts
+++ b/src/midi-player.ts
@@ -3,6 +3,8 @@ import { IMidiFile, TMidiEvent } from 'midi-json-parser-worker';
 import { IMidiOutput, IMidiPlayer, IMidiPlayerOptions, IState } from './interfaces';
 import { Scheduler } from './scheduler';
 
+const ALL_SOUND_OFF_EVENT_DATA = Array.from({ length: 16 }, (_, index) => new Uint8Array([176 + index, 120, 0]));
+
 export class MidiPlayer implements IMidiPlayer {
     private _encodeMidiMessage: (event: TMidiEvent) => Uint8Array;
 
@@ -60,6 +62,7 @@ export class MidiPlayer implements IMidiPlayer {
 
         // Bug #1: Chrome does not yet implement the clear() method.
         this._midiOutput.clear?.();
+        ALL_SOUND_OFF_EVENT_DATA.forEach((data) => this._midiOutput.send(data));
         this._stop(this._state);
     }
 

--- a/src/midi-player.ts
+++ b/src/midi-player.ts
@@ -58,6 +58,8 @@ export class MidiPlayer implements IMidiPlayer {
             throw new Error('The player is already stopped.');
         }
 
+        // Bug #1: Chrome does not yet implement the clear() method.
+        this._midiOutput.clear?.();
         this._stop(this._state);
     }
 

--- a/test/expectation/chrome/canary/midi-output.js
+++ b/test/expectation/chrome/canary/midi-output.js
@@ -1,0 +1,9 @@
+describe('MIDIOutput', () => {
+    describe('clear()', () => {
+        // #1
+
+        it('should not be implemented', () => {
+            expect(MIDIOutput.prototype.clear).to.be.undefined;
+        });
+    });
+});

--- a/test/expectation/chrome/canary/midi-output.js
+++ b/test/expectation/chrome/canary/midi-output.js
@@ -1,6 +1,6 @@
 describe('MIDIOutput', () => {
     describe('clear()', () => {
-        // #1
+        // #1 https://issues.chromium.org/issues/40411677
 
         it('should not be implemented', () => {
             expect(MIDIOutput.prototype.clear).to.be.undefined;

--- a/test/expectation/chrome/current/midi-output.js
+++ b/test/expectation/chrome/current/midi-output.js
@@ -1,0 +1,9 @@
+describe('MIDIOutput', () => {
+    describe('clear()', () => {
+        // #1
+
+        it('should not be implemented', () => {
+            expect(MIDIOutput.prototype.clear).to.be.undefined;
+        });
+    });
+});

--- a/test/expectation/chrome/current/midi-output.js
+++ b/test/expectation/chrome/current/midi-output.js
@@ -1,6 +1,6 @@
 describe('MIDIOutput', () => {
     describe('clear()', () => {
-        // #1
+        // #1 https://issues.chromium.org/issues/40411677
 
         it('should not be implemented', () => {
             expect(MIDIOutput.prototype.clear).to.be.undefined;

--- a/test/mock/midi-output.js
+++ b/test/mock/midi-output.js
@@ -1,5 +1,6 @@
 import { stub } from 'sinon';
 
 export const midiOutputMock = {
+    clear: stub(),
     send: stub()
 };

--- a/test/unit/midi-player.js
+++ b/test/unit/midi-player.js
@@ -36,6 +36,7 @@ describe('MidiPlayer', () => {
         sequence = 'a fake sequence';
 
         midiFileSlicerMock.slice.resetHistory();
+        midiOutputMock.clear.resetHistory();
         midiOutputMock.send.resetHistory();
         performanceMock.now.resetHistory();
 
@@ -147,6 +148,13 @@ describe('MidiPlayer', () => {
                 midiFileSlicerMock.slice.returns([{ event, time: 500 }]);
 
                 midiPlayer.play().then(then);
+            });
+
+            it('should call clear() on the midiOutput', () => {
+                midiPlayer.stop();
+
+                expect(midiOutputMock.clear).to.have.been.calledOnce;
+                expect(midiOutputMock.clear).to.have.been.calledWithExactly();
             });
 
             it('should return undefined', () => {

--- a/test/unit/midi-player.js
+++ b/test/unit/midi-player.js
@@ -148,6 +148,9 @@ describe('MidiPlayer', () => {
                 midiFileSlicerMock.slice.returns([{ event, time: 500 }]);
 
                 midiPlayer.play().then(then);
+
+                midiOutputMock.clear.resetHistory();
+                midiOutputMock.send.resetHistory();
             });
 
             it('should call clear() on the midiOutput', () => {
@@ -155,6 +158,28 @@ describe('MidiPlayer', () => {
 
                 expect(midiOutputMock.clear).to.have.been.calledOnce;
                 expect(midiOutputMock.clear).to.have.been.calledWithExactly();
+            });
+
+            it('should call send() on the midiOutput', () => {
+                midiPlayer.stop();
+
+                expect(midiOutputMock.send).to.have.been.callCount(16);
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([176, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([177, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([178, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([179, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([180, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([181, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([182, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([183, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([184, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([185, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([186, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([187, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([188, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([189, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([190, 120, 0]));
+                expect(midiOutputMock.send).to.have.been.calledWithExactly(new Uint8Array([191, 120, 0]));
             });
 
             it('should return undefined', () => {


### PR DESCRIPTION
This PR adds the call to `clear()` and the sending of "all sound off" messages when the player gets stopped.

It also adds a test to check if the implementation of `clear()` is still missing in Chrome.

If you don't mind @infojunkie, I would really appreciate if you could take a look.